### PR TITLE
fix unexported TurnstileTaskSolution token field

### DIFF
--- a/pkg/tasks/turnstileTask.go
+++ b/pkg/tasks/turnstileTask.go
@@ -129,5 +129,5 @@ func (t TurnstileTask) Validate() error {
 }
 
 type TurnstileTaskSolution struct {
-	token string `json:"token"`
+	Token string `json:"token"`
 }


### PR DESCRIPTION
Greetings. I was in need to use this part of module and found unexported field that was preventing from getting correct serialization of response.